### PR TITLE
Converted libs to use ARC, fixed memory leaks and upload cancellation

### DIFF
--- a/MultiPartFileUploader.h
+++ b/MultiPartFileUploader.h
@@ -28,7 +28,7 @@
 /**
  Location of file being uploaded on local machine
  */
-@property (nonatomic, retain) NSURL *filePathUrl;
+@property (nonatomic, strong) NSURL *filePathUrl;
 
 /**
  Create an instance of an uploader with S3 credentials

--- a/MultiPartFileUploader.h
+++ b/MultiPartFileUploader.h
@@ -35,9 +35,10 @@
  @param s3Key The Access Key Id for your S3 account
  @param s3Secret The Secret Access Key for your S3 account
  @param s3Bucket The S3 bucket you want to use to store your file
+ @param s3FileKey The S3 key you want to use to store your file - pass nil to have the key generated from the filePathUrl
  @returns a new instance of MultiPartFileUploader
  */
-- (id)initWithS3Key:(NSString *)s3Key secret:(NSString *)s3Secret bucket:(NSString *)s3Bucket;
+- (id)initWithS3Key:(NSString *)s3Key secret:(NSString *)s3Secret bucket:(NSString *)s3Bucket fileKey:(NSString*)s3FileKey;
 
 /**
  Upload an entire file in chunks to the given S3 bucket

--- a/MultiPartFileUploader.m
+++ b/MultiPartFileUploader.m
@@ -137,6 +137,7 @@ const int PART_SIZE = (5 * 1024 * 1024); // 5MB is the smallest part size allowe
     if(!self.isCancelled) {
         [self setIsCancelled:YES];
         [self.queue cancelAllOperations];
+        //[self.outstandingPartNumbers removeAllObjects];
         [self abortUpload];
     }
 }
@@ -227,8 +228,8 @@ const int PART_SIZE = (5 * 1024 * 1024); // 5MB is the smallest part size allowe
 - (void)abortUpload
 {
     // We may need to call this several times. We try after each outstanding part has uploaded and eventually we should be clean.
-    S3AbortMultipartUploadRequest *abortRequest = [[S3AbortMultipartUploadRequest alloc] initWithMultipartUpload:[self upload]];
-    [[self s3] abortMultipartUpload:abortRequest];
+    //S3AbortMultipartUploadRequest *abortRequest = [[S3AbortMultipartUploadRequest alloc] initWithMultipartUpload:[self upload]];
+    //[[self s3] abortMultipartUpload:abortRequest];
     
     if( [self delegate] && [[self delegate] respondsToSelector:@selector(fileUploaderDidAbort:)] )
     {

--- a/MultiPartFileUploader.m
+++ b/MultiPartFileUploader.m
@@ -12,6 +12,7 @@
 @property (nonatomic, copy) NSString *s3Key;
 @property (nonatomic, copy) NSString *s3Secret;
 @property (nonatomic, copy) NSString *s3Bucket;
+@property (nonatomic, copy) NSString *s3FileKey;
 @property (nonatomic, assign) id<MultiPartFileUploaderDelegate> delegate;
 @property (nonatomic, retain) AmazonS3Client *s3;
 @property (nonatomic, retain) S3MultipartUpload *upload;
@@ -30,6 +31,7 @@ const int PART_SIZE = (5 * 1024 * 1024); // 5MB is the smallest part size allowe
 @synthesize s3Key=_s3Key;
 @synthesize s3Secret=_s3Secret;
 @synthesize s3Bucket=_s3Bucket;
+@synthesize s3FileKey=_s3FileKey;
 @synthesize delegate=_delegate;
 @synthesize s3=_s3;
 @synthesize upload=_upload;
@@ -40,7 +42,7 @@ const int PART_SIZE = (5 * 1024 * 1024); // 5MB is the smallest part size allowe
 @synthesize filePathUrl=_filePathUrl;
 @synthesize isCancelled=_isCancelled;
 
-- (id)initWithS3Key:(NSString *)s3Key secret:(NSString *)s3Secret bucket:(NSString *)s3Bucket
+- (id)initWithS3Key:(NSString *)s3Key secret:(NSString *)s3Secret bucket:(NSString *)s3Bucket fileKey:(NSString*)s3FileKey;
 {
     self = [super init];
     if( self )
@@ -48,6 +50,7 @@ const int PART_SIZE = (5 * 1024 * 1024); // 5MB is the smallest part size allowe
         [self setS3Key:s3Key];
         [self setS3Secret:s3Secret];
         [self setS3Bucket:s3Bucket];
+        [self setS3FileKey:s3FileKey];
         [self setS3:[[[AmazonS3Client alloc] initWithAccessKey:[self s3Key] withSecretKey:[self s3Secret]] autorelease]];
     }
     return self;
@@ -111,7 +114,7 @@ const int PART_SIZE = (5 * 1024 * 1024); // 5MB is the smallest part size allowe
     
     @try 
     {
-        NSString *keyOnS3 = [self fileKeyOnS3:[[self filePathUrl] relativePath]];
+        NSString *keyOnS3 =  self.s3FileKey ?: [self fileKeyOnS3:[[self filePathUrl] relativePath]];
         S3InitiateMultipartUploadRequest *initReq = [[[S3InitiateMultipartUploadRequest alloc] initWithKey:keyOnS3 inBucket:[self s3Bucket]] autorelease];
         [self setUpload:[[[self s3] initiateMultipartUpload:initReq] multipartUpload]];
         [self setCompReq:[[[S3CompleteMultipartUploadRequest alloc] initWithMultipartUpload:[self upload]] autorelease]];

--- a/MultiPartFileUploader.m
+++ b/MultiPartFileUploader.m
@@ -146,14 +146,16 @@ const int PART_SIZE = (5 * 1024 * 1024); // 5MB is the smallest part size allowe
 
 - (void)cancel
 {
-    [self setIsCancelled:YES];
-    
-    for (PartUploadTask *task in [self tasks]) 
-    {
-        [task cancel];
+    if(!self.isCancelled) {
+        [self setIsCancelled:YES];
+        
+        for (PartUploadTask *task in [self tasks]) 
+        {
+            [task cancel];
+        }
+     
+        [self abortUpload];
     }
- 
-    [self abortUpload];
 }
 
 #pragma mark - part upload delegate methods

--- a/MultiPartFileUploader.m
+++ b/MultiPartFileUploader.m
@@ -116,6 +116,7 @@ const int PART_SIZE = (5 * 1024 * 1024); // 5MB is the smallest part size allowe
     {
         NSString *keyOnS3 =  self.s3FileKey ?: [self fileKeyOnS3:[[self filePathUrl] relativePath]];
         S3InitiateMultipartUploadRequest *initReq = [[[S3InitiateMultipartUploadRequest alloc] initWithKey:keyOnS3 inBucket:[self s3Bucket]] autorelease];
+        initReq.cannedACL = [S3CannedACL publicRead];
         [self setUpload:[[[self s3] initiateMultipartUpload:initReq] multipartUpload]];
         [self setCompReq:[[[S3CompleteMultipartUploadRequest alloc] initWithMultipartUpload:[self upload]] autorelease]];
         

--- a/MultiPartFileUploader.m
+++ b/MultiPartFileUploader.m
@@ -56,6 +56,7 @@ const int PART_SIZE = (5 * 1024 * 1024); // 5MB is the smallest part size allowe
 - (void)dealloc
 {
     _delegate = nil;
+    [_tasks makeObjectsPerformSelector:@selector(setDelegate:) withObject:nil];
     [_tasks removeAllObjects];
     [_tasks release];
     [_outstandingPartNumbers removeAllObjects];

--- a/MultiPartFileUploader.m
+++ b/MultiPartFileUploader.m
@@ -165,7 +165,9 @@ const int PART_SIZE = (5 * 1024 * 1024); // 5MB is the smallest part size allowe
     
     if( [self delegate] && [[self delegate] respondsToSelector:@selector(fileUploaderDidFailToUploadFile:)] )
     {
-        [[self delegate] fileUploaderDidFailToUploadFile:self];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[self delegate] fileUploaderDidFailToUploadFile:self];
+        });
     }
 }
 
@@ -173,7 +175,9 @@ const int PART_SIZE = (5 * 1024 * 1024); // 5MB is the smallest part size allowe
 {
     if( [self delegate] && [[self delegate] respondsToSelector:@selector(fileUploader:didUploadPercentage:ofPartNumber:)] )
     {
-        [[self delegate] fileUploader:self didUploadPercentage:progress ofPartNumber:[task partNumber]];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[self delegate] fileUploader:self didUploadPercentage:progress ofPartNumber:[task partNumber]];
+        });
     }
 }
 
@@ -191,7 +195,9 @@ const int PART_SIZE = (5 * 1024 * 1024); // 5MB is the smallest part size allowe
     
     if( [self delegate] && [[self delegate] respondsToSelector:@selector(fileUploader:didUploadPartNumber:etag:)] )
     {
-        [[self delegate] fileUploader:self didUploadPartNumber:partNumber etag:etag];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[self delegate] fileUploader:self didUploadPartNumber:partNumber etag:etag];
+        });
     }
 
     if( [[self outstandingPartNumbers] count] == 0 )
@@ -200,7 +206,9 @@ const int PART_SIZE = (5 * 1024 * 1024); // 5MB is the smallest part size allowe
 
         if( [self delegate] && [[self delegate] respondsToSelector:@selector(fileUploader:didFinishUploadingFileTo:)] )
         {
-            [[self delegate] fileUploader:self didFinishUploadingFileTo:[[self upload] key]];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [[self delegate] fileUploader:self didFinishUploadingFileTo:[[self upload] key]];
+            });
         }
     }
 }
@@ -242,7 +250,9 @@ const int PART_SIZE = (5 * 1024 * 1024); // 5MB is the smallest part size allowe
     
     if( [self delegate] && [[self delegate] respondsToSelector:@selector(fileUploaderDidAbort:)] )
     {
-        [[self delegate] fileUploaderDidAbort:self];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[self delegate] fileUploaderDidAbort:self];
+        });
     }
 }
 

--- a/PartUploadTask.h
+++ b/PartUploadTask.h
@@ -25,11 +25,11 @@
     BOOL isFinished;
 }
 
-@property (nonatomic, assign) id<PartUploadTaskDelegate> delegate;
+@property (nonatomic, strong) id<PartUploadTaskDelegate> delegate;
 @property (nonatomic, assign) NSInteger partNumber;
-@property (nonatomic, retain) NSData *data;
-@property (nonatomic, retain) AmazonS3Client *s3;
-@property (nonatomic, retain) S3MultipartUpload *upload;
+@property (nonatomic, strong) NSData *data;
+@property (nonatomic, strong) AmazonS3Client *s3;
+@property (nonatomic, strong) S3MultipartUpload *upload;
 @property (nonatomic, assign) float percentageUploaded;
 
 - (id)initWithPartNumber:(NSInteger)partNumber dataToUpload:(NSData *)data s3Client:(AmazonS3Client *)s3 s3MultipartUpload:(S3MultipartUpload *)upload;

--- a/PartUploadTask.m
+++ b/PartUploadTask.m
@@ -141,8 +141,11 @@
 
 - (void)request:(AmazonServiceRequest *)request didSendData:(NSInteger)bytesWritten totalBytesWritten:(NSInteger)totalBytesWritten totalBytesExpectedToWrite:(NSInteger)totalBytesExpectedToWrite
 {
-    // We cannot cancel this request so there's no point processing the cancelled state here
-    // Instead we return finished when finished and let the controller abort the overall upload
+    if(self.isCancelled) {
+        [request cancel];
+        [self finish];
+        return;
+    }
     
     float percentage = (float)totalBytesWritten / (float)totalBytesExpectedToWrite;
     if( ![self isSignificantIncrease:percentage] )

--- a/PartUploadTask.m
+++ b/PartUploadTask.m
@@ -72,7 +72,7 @@
     upReq.stream = stream;
     upReq.delegate = self;
     
-    [[self s3] uploadPart:upReq];
+    [[self s3] uploadPart:[upReq autorelease]];
     
     
     // This is a horrible hack. Without this the method returns immediately and the upload delegates never get called.

--- a/PartUploadTask.m
+++ b/PartUploadTask.m
@@ -132,7 +132,7 @@
 {
     [self finish];
 
-    if( [self delegate] )
+    if( [self delegate] && [[self delegate] respondsToSelector:@selector(partUploadTaskDidFail:)])
     {
         [[self delegate] partUploadTaskDidFail:self];
     }

--- a/PartUploadTask.m
+++ b/PartUploadTask.m
@@ -35,7 +35,7 @@
 
 - (void)dealloc
 {
-    _delegate = nil;
+    [_delegate release];
     [_data release];
     [_s3 release];
     [_upload release];

--- a/PartUploadTask.m
+++ b/PartUploadTask.m
@@ -33,14 +33,6 @@
     return self;
 }
 
-- (void)dealloc
-{
-    [_delegate release];
-    [_data release];
-    [_s3 release];
-    [_upload release];
-    [super dealloc];
-}
 
 - (void)start
 {
@@ -72,7 +64,7 @@
     upReq.stream = stream;
     upReq.delegate = self;
     
-    [[self s3] uploadPart:[upReq autorelease]];
+    [[self s3] uploadPart:upReq];
     
     
     // This is a horrible hack. Without this the method returns immediately and the upload delegates never get called.


### PR DESCRIPTION
The upload cancellation now does not call abort request so the upload can be resumed in the future. The API could be modified to have cancel and cancel&abort methods.
